### PR TITLE
Normalization character case in many files

### DIFF
--- a/modules/captcha/classes/captcha.php
+++ b/modules/captcha/classes/captcha.php
@@ -433,7 +433,7 @@ abstract class Captcha
 	{
 		// Output html element
 		if ($html === TRUE)
-			return '<img src="'.url::site('captcha/'.Captcha::$config['group']).'" width="'.Captcha::$config['width'].'" height="'.Captcha::$config['height'].'" alt="Captcha" class="captcha" />';
+			return '<img src="'.URL::site('captcha/'.Captcha::$config['group']).'" width="'.Captcha::$config['width'].'" height="'.Captcha::$config['height'].'" alt="Captcha" class="captcha" />';
 
 		// Send the correct HTTP header
 		Request::current()->response()

--- a/modules/captcha/classes/controller/captcha.php
+++ b/modules/captcha/classes/controller/captcha.php
@@ -2,7 +2,7 @@
 /**
  * Outputs the dynamic Captcha resource.
  * Usage: Call the Captcha controller from a view, e.g.
- *        <img src="<?php echo url::site('captcha') ?>" />
+ *        <img src="<?php echo URL::site('captcha') ?>" />
  *
  * $Id: captcha.php 3769 2008-12-15 00:48:56Z zombor $
  *

--- a/modules/gleez/classes/gleez/form.php
+++ b/modules/gleez/classes/gleez/form.php
@@ -1,11 +1,10 @@
 <?php defined('SYSPATH') or die('No direct script access.');
 /**
- * Form helper class.
+ * Form helper class
  *
- * @package		Gleez
- * @category	Form
+ * @package		Gleez\Helper\Form
  * @author		Sandeep Sangamreddi - Gleez
- * @copyright	(c) 2013 Gleez Technologies
+ * @copyright	(c) 2011-2013 Gleez Technologies
  * @license		http://gleezcms.org/license
  */
 class Gleez_Form extends Kohana_Form {
@@ -13,8 +12,9 @@ class Gleez_Form extends Kohana_Form {
 	/**
 	 * Creates a form input. If no type is specified, a "text" type input will
 	 * be returned.
-	 *
-	 *     echo Form::input('username', $username);
+	 * <code>
+	 *   echo Form::input('username', $username);
+	 * </code>
 	 *
 	 * @param   string  input name
 	 * @param   string  input value
@@ -37,25 +37,25 @@ class Gleez_Form extends Kohana_Form {
 			// Default type is text
 			$attributes['type'] = 'text';
 		}
-	
+
 		$out = '';
-	
+
 		if( $attributes['type'] === 'text' AND $url )
 		{
 			$attributes['class'] = isset($attributes['class']) ? $attributes['class'].' form-autocomplete' : 'form-autocomplete';
 			$attributes['id'] = $name;
 			// Assign the autocomplete js file
 			Assets::js('autocomplete', 'media/js/autocomplete.js', 'gleez');
-		
+
 			$attributes['data-autocomplete-path'] = URL::site($url, TRUE);
 			$attributes['data-autocomplete-smart'] = $smart;
 		}
-	
+
 		$out .= '<input'.HTML::attributes($attributes).' />';
 
 		return $out;
 	}
-	
+
 	/**
 	 * Creates CSRF token input.
 	 *
@@ -78,19 +78,17 @@ class Gleez_Form extends Kohana_Form {
 	 * @uses    Form::select
 	 */
 	public static function weight($name, $selected = 0, array $attributes = NULL, $delta = 15) {
-		
+
 		for ($n = (-1 * $delta); $n <= $delta; $n++)
 		{
 			$options[$n] = $n;
 		}
 		return Form::select($name, $options, $selected, $attributes);
 	}
-	
+
 	/**
 	 * create a form field for filtering
 	 *
-	 * @access public
-	 * @static
 	 * @param string  $column
 	 * @param array  $filtervals
 	 * @return string
@@ -117,12 +115,10 @@ class Gleez_Form extends Kohana_Form {
 
 		return Form::input($name, $value, $attributes);
 	}
-	
+
 	/**
 	 * create a 'new x button'
 	 *
-	 * @access public
-	 * @static
 	 * @param string  $name
 	 * @param string  $title. (default: null)
 	 * @param string  $url.   (default: null)
@@ -131,11 +127,11 @@ class Gleez_Form extends Kohana_Form {
 	public static function newButton($name, $title = null, $url = null)
 	{
 		$url = ($url) ? $url : Request::current()->uri(array('action' => 'add'));
-		$title = ($title) ? $title : Gleez::spriteImg('add') . __('add :object', array(':object' => __($name)));
+		$title = ($title) ? $title : HTML::sprite_img('add') . __('add :object', array(':object' => __($name)));
 
-		return Html::anchor($url, $title, array('class' => 'button positive'));
+		return HTML::anchor($url, $title, array('class' => 'button positive'));
 	}
-	
+
 	/**
 	 * Generates an opening HTML form tag.
 	 *
@@ -158,7 +154,7 @@ class Gleez_Form extends Kohana_Form {
 	 * @uses    ACL::key
 	 */
 	public static function open($action = NULL, array $attributes = NULL)
-	{		
+	{
 		if ($action instanceof Request)
 		{
 			// Use the current URI
@@ -175,7 +171,7 @@ class Gleez_Form extends Kohana_Form {
 			// Make the URI absolute
 			$action = URL::site($action);
 		}
-	
+
 		// Add the form action to the attributes
 		$attributes['action'] = $action;
 
@@ -184,18 +180,18 @@ class Gleez_Form extends Kohana_Form {
 		{
 			//properly parse the path and query
 			$url = URL::explode($action);
-		
-			//On seriously malformed URLs, parse_url() may return FALSE. 
+
+			//On seriously malformed URLs, parse_url() may return FALSE.
 			if( isset($url['path']) AND is_array($url['query_params']) )
 			{
 				//add destination param
 				$url['query_params']['destination'] = $desti;
-		
+
 				//set the form action parameter
 				$attributes['action'] = $url['path'].URL::query($url['query_params']);
 			}
 		}
-	
+
 		// Only accept the default character set
 		$attributes['accept-charset'] = Kohana::$charset;
 
@@ -206,17 +202,17 @@ class Gleez_Form extends Kohana_Form {
 		}
 
 		$out = "<form".HTML::attributes($attributes).">\n";
-		
+
 		if( Gleez::$installed )
 		{
 			// Assign the global form css file
 			Assets::css('form', 'media/css/form.css', array('weight' => 2));
-		
+
 			$action  = md5($action.CSRF::key());
 			$out 	.= Form::hidden('_token', CSRF::token(false, $action))."\n";
 			$out 	.= Form::hidden('_action', $action)."\n";
 		}
-		
+
 		return $out;
 	}
 
@@ -300,7 +296,7 @@ class Gleez_Form extends Kohana_Form {
 
 		return '<select'.HTML::attributes($attributes).'>'.$options.'</select>';
 	}
-	
+
         public static function radios($name, array $options = NULL, $selected = NULL, array $attributes = NULL)
         {
 		if ( !isset($attributes['class']))
@@ -311,16 +307,16 @@ class Gleez_Form extends Kohana_Form {
 		{
 			$attributes['class'] .= ' radio';
 		}
-		
+
 		$output = '';
-		
+
                 foreach ($options as $k => $v)
                 {
-                        $output .= Form::label($name, Form::radio($name, $k, ($selected == $k) ? TRUE : FALSE).Text::plain($v), $attributes);   
+                        $output .= Form::label($name, Form::radio($name, $k, ($selected == $k) ? TRUE : FALSE).Text::plain($v), $attributes);
                 }
 		return $output;
         }
-	
+
 	public static function checkboxes($name, array $options = NULL, array $selected = NULL, array $attributes = NULL)
 	{
 		if ( !isset($attributes['class']))
@@ -331,18 +327,18 @@ class Gleez_Form extends Kohana_Form {
 		{
 			$attributes['class'] .= ' checkbox';
 		}
-		
+
 		if ($selected == NULL) $selected = array();
-		
+
 		$output = '';
-		
+
                 foreach ($options as $k => $v)
                 {
-                        $output .= Form::label($name, Form::checkbox($name, $k, (in_array($k, $selected) ? TRUE : FALSE)).Text::plain($v), $attributes);   
+                        $output .= Form::label($name, Form::checkbox($name, $k, (in_array($k, $selected) ? TRUE : FALSE)).Text::plain($v), $attributes);
                 }
                 return $output;
 	}
-	
+
 	public static function mycheckbox($name, $option = NULL, $value = 0, $selected = NULL, array $attributes = NULL)
 	{
 		if ( !isset($attributes['class']))
@@ -353,14 +349,14 @@ class Gleez_Form extends Kohana_Form {
 		{
 			$attributes['class'] .= ' checkbox';
 		}
-		
+
 		$output = '';
 		$output .= Form::hidden($name, 0);
 		$output .= Form::label($name, Form::checkbox( $name, $value, ( (($selected != 0) AND ($selected == $value)) ? TRUE : FALSE ) ).Text::plain($option), $attributes);
-		
+
 		return $output;
 	}
-	
+
 	/**
 	 * Creates a select form input with raw labels.
 	 *
@@ -465,5 +461,5 @@ class Gleez_Form extends Kohana_Form {
 
 		return '<select'.HTML::attributes($attributes).'>'.$options.'</select>';
 	}
-	
+
 }// End Form

--- a/modules/gleez/classes/gleez/html.php
+++ b/modules/gleez/classes/gleez/html.php
@@ -85,7 +85,7 @@ class Gleez_HTML extends Kohana_HTML {
 			$output = '<ul'. HTML::attributes($attributes) .'>';
 
 			if (is_null(HTML::$current_route))
-				HTML::$current_route = Url::site(Request::current()->uri());
+				HTML::$current_route = URL::site(Request::current()->uri());
 
 			$num_links = count($links);
 			$i = 1;
@@ -141,7 +141,7 @@ class Gleez_HTML extends Kohana_HTML {
 		if (count($tabs) > 0)
 		{
 			if (is_null(HTML::$current_route))
-				HTML::$current_route = Url::site(Request::current()->uri());
+				HTML::$current_route = URL::site(Request::current()->uri());
 
 			$output = '<ul'. HTML::attributes($attributes) .'>';
 
@@ -202,11 +202,11 @@ class Gleez_HTML extends Kohana_HTML {
 		}
 		elseif ($uri)
 		{
-			return strpos(HTML::$current_route, Url::site($uri)) === 0;
+			return strpos(HTML::$current_route, URL::site($uri)) === 0;
 		}
 		else
 		{
-			return HTML::$current_route == Url::base();
+			return HTML::$current_route == URL::base();
 		}
 	}
 

--- a/modules/gleez/classes/gleez/menu.php
+++ b/modules/gleez/classes/gleez/menu.php
@@ -164,7 +164,7 @@ class Gleez_Menu {
 		if( empty( $items ) ) return;
 	
 		$i++;
-		HTML::$current_route = Url::site(Request::current()->uri());
+		HTML::$current_route = URL::site(Request::current()->uri());
 	
 
 		$attrs['class'] = empty($attrs['class']) ? 'level-'.$i : $attrs['class'].' level-'.$i;

--- a/modules/gleez/classes/gleez/text.php
+++ b/modules/gleez/classes/gleez/text.php
@@ -31,7 +31,7 @@ abstract class Gleez_Text extends Kohana_Text {
 	 */
 	public static function plain($text)
 	{
-		return Html::chars($text);
+		return HTML::chars($text);
 	}
 
 	/**

--- a/modules/gleez/classes/gleez/url.php
+++ b/modules/gleez/classes/gleez/url.php
@@ -110,7 +110,7 @@ class Gleez_URL extends Kohana_URL {
 			$query = URL::query(array('sort' => $col, 'order' => $order));
 
 
-			$string .= Html::anchor(Request::current()->uri() .  $query, $anchor_string, array('class' => $class . ' sort'));
+			$string .= HTML::anchor(Request::current()->uri() .  $query, $anchor_string, array('class' => $class . ' sort'));
 		}
 
 		return $string;

--- a/modules/gleez/config/tags.php
+++ b/modules/gleez/config/tags.php
@@ -5,7 +5,7 @@ return array(
         // Whether to normalize tags at all (recommended, as raw tags are preserved anyway.)
         'normalize_tags'                => FALSE,
         
-        // Use Kohana's url::title() helper for normalization
+        // Use Kohana's URL::title() helper for normalization
         'use_gleez_normalization'       => FALSE,
 
         // If 'use_gleez_normalization' is set to FALSE, you can define your own normalization here.

--- a/modules/gleez/views/admin/format/list.php
+++ b/modules/gleez/views/admin/format/list.php
@@ -31,7 +31,7 @@
 			</td>
 			
 			<td class="action">
-				<?php echo Html::anchor(Route::get('admin/format')->uri(array('id' => $id, 'action' =>
+				<?php echo HTML::anchor(Route::get('admin/format')->uri(array('id' => $id, 'action' =>
 				     'configure')),__("Configure"), array('class'=>'action-list', 'title'=>__('Configure'))) ?>
 			</td>
 		</tr>

--- a/modules/gleez/views/admin/path/form.php
+++ b/modules/gleez/views/admin/path/form.php
@@ -30,5 +30,5 @@
  	<?php echo Form::input('alias', $post->alias, array('class' => 'text medium')); ?>
 </div>
 
-<?php echo form::button('path', __('Submit'), array('class' => 'btn btn-primary')) ?>
-<?php echo form::close() ?>
+<?php echo Form::button('path', __('Submit'), array('class' => 'btn btn-primary')) ?>
+<?php echo Form::close() ?>

--- a/modules/gleez/views/admin/path/list.php
+++ b/modules/gleez/views/admin/path/list.php
@@ -26,8 +26,8 @@
             </td>
         
             <td class="action">
-                 <?php echo html::anchor(Route::get('admin/path')->uri(array('action' => 'edit', 'id' => $path->id)), __('Edit'), array('class'=>'action-edit', 'title'=> __('Edit Alias'))) ?>
-                 <?php echo html::anchor(Route::get('admin/path')->uri(array('action' => 'delete', 'id' => $path->id)), __('Delete'), array('class'=>'action-delete', 'title'=> __('Delete Alias'))) ?>
+                 <?php echo HTML::anchor(Route::get('admin/path')->uri(array('action' => 'edit', 'id' => $path->id)), __('Edit'), array('class'=>'action-edit', 'title'=> __('Edit Alias'))) ?>
+                 <?php echo HTML::anchor(Route::get('admin/path')->uri(array('action' => 'delete', 'id' => $path->id)), __('Delete'), array('class'=>'action-delete', 'title'=> __('Delete Alias'))) ?>
 		</td>
           </tr>
           <?php endforeach ?>

--- a/modules/gleez/views/admin/settings.php
+++ b/modules/gleez/views/admin/settings.php
@@ -72,7 +72,7 @@
 
 	<div class="control-group <?php echo isset($errors['offline_message']) ? 'error': ''; ?>">
 	    <?php echo Form::label('offline_message', __('Offline Message'), array('class' => 'control-label')) ?>
-	    <?php echo form::textarea('offline_message', $post['offline_message'], array('class' => 'textarea span12', 'rows' => 5)) ?>
+	    <?php echo Form::textarea('offline_message', $post['offline_message'], array('class' => 'textarea span12', 'rows' => 5)) ?>
         </div>
 
 	<div class="control-group <?php echo isset($errors['timezone']) ? 'error': ''; ?>">

--- a/modules/gleez/views/admin/tag/form.php
+++ b/modules/gleez/views/admin/tag/form.php
@@ -42,6 +42,6 @@
 	<?php echo Form::input('path', $path, array('class' => 'text small slug')); ?>
 </div>
 
-<?php echo form::button('tag', __('Submit'), array('class' => 'btn btn-primary')) ?>
+<?php echo Form::button('tag', __('Submit'), array('class' => 'btn btn-primary')) ?>
 
-<?php echo form::close() ?>
+<?php echo Form::close() ?>

--- a/modules/gleez/views/admin/tag/list.php
+++ b/modules/gleez/views/admin/tag/list.php
@@ -23,16 +23,16 @@
             </td>
 
             <td id="tag-slug-<?php echo $tag->id ?>">
-              <?php echo Html::anchor($tag->url, $tag->url) ?>
+              <?php echo HTML::anchor($tag->url, $tag->url) ?>
             </td>
 	
             <td id="tag-type-<?php echo $tag->id ?>">
-              <?php echo Html::chars($tag->type) ?>
+              <?php echo HTML::chars($tag->type) ?>
             </td>
         
             <td class="action">
-                 <?php echo html::anchor(Route::get('admin/tag')->uri(array('action' => 'edit', 'id' => $tag->id)), __('Edit'), array('class'=>'action-edit', 'title'=> __('Edit Tag'))) ?>
-                 <?php echo html::anchor(Route::get('admin/tag')->uri(array('action' => 'delete', 'id' => $tag->id)), __('Delete'), array('class'=>'action-delete', 'title'=> __('Delete Tag'))) ?>
+                 <?php echo HTML::anchor(Route::get('admin/tag')->uri(array('action' => 'edit', 'id' => $tag->id)), __('Edit'), array('class'=>'action-edit', 'title'=> __('Edit Tag'))) ?>
+                 <?php echo HTML::anchor(Route::get('admin/tag')->uri(array('action' => 'delete', 'id' => $tag->id)), __('Delete'), array('class'=>'action-delete', 'title'=> __('Delete Tag'))) ?>
 		</td>
           </tr>
           <?php endforeach ?>

--- a/modules/gleez/views/errors/stack.php
+++ b/modules/gleez/views/errors/stack.php
@@ -114,7 +114,7 @@ function koggle(elem)
 	    <br>
       
       <div id="kohana_error">
-	<h1><span class="type"><?php echo $type ?> [ <?php echo $code ?> ]:</span> <span class="message"><?php echo html::chars($message) ?></span></h1>
+	<h1><span class="type"><?php echo $type ?> [ <?php echo $code ?> ]:</span> <span class="message"><?php echo HTML::chars($message) ?></span></h1>
 	<div id="<?php echo $error_id ?>" class="content">
 		<p><span class="file"><?php echo Debug::path($file) ?> [ <?php echo $line ?> ]</span></p>
 		<?php echo Debug::source($file, $line) ?>

--- a/modules/gleez/views/post/list.php
+++ b/modules/gleez/views/post/list.php
@@ -5,9 +5,8 @@
 	<div id="post-<?php echo $i; ?>" class="post<?php if ($post->sticky) { echo ' sticky'; } ?>
 					<?php echo ' post-'. $post->status; ?>">
                 
-                <h2 class="post-title"><?php echo html::anchor($post->url, $post->title) ?></h2>
-                
-                <?php //echo View::factory($post->type.'/post')->set($post->type, $post)->set('use_excerpt', TRUE); ?>
+                <h2 class="post-title"><?php echo HTML::anchor($post->url, $post->title) ?></h2>
+
                 <?php echo isset( $teaser ) ? $post->teaser : $post->content ?>
 	</div>
 	

--- a/modules/unittest/classes/kohana/unittest/helpers.php
+++ b/modules/unittest/classes/kohana/unittest/helpers.php
@@ -117,7 +117,7 @@ class Kohana_Unittest_Helpers {
 				// PHPUnit makes a backup of superglobals automatically
 				$$option = $value;
 			}
-			// If this is a static property i.e. Html::$windowed_urls
+			// If this is a static property i.e. HTML::$windowed_urls
 			elseif (strpos($option, '::$') !== FALSE)
 			{
 				list($class, $var) = explode('::$', $option, 2);

--- a/modules/user/classes/controller/admin/role.php
+++ b/modules/user/classes/controller/admin/role.php
@@ -12,11 +12,8 @@ class Controller_Admin_Role extends Controller_Admin {
 
 	public function before()
 	{
-		if($this->request->action() == 'index' )
-		{
-			//$this->request->action('list');
-		}
-		//Acl::Required('administer users');
+		ACL::Required('administer users');
+
 		parent::before();
 	}
 

--- a/modules/user/classes/model/auth/user.php
+++ b/modules/user/classes/model/auth/user.php
@@ -129,7 +129,7 @@ class Model_Auth_User extends ORM {
 	{
 		if( $field === 'name' OR $field === 'mail' )
 		{
-			return Html::chars( parent::__get($field) );
+			return HTML::chars( parent::__get($field) );
 		}
 
 		// Return the best version of the user's name. Either their specified
@@ -137,7 +137,7 @@ class Model_Auth_User extends ORM {
 		if( $field === 'nick' )
 		{
 			$nick = parent::__get('nick');
-			return empty($nick) ? Html::chars( $this->name ) : Html::chars($nick);
+			return empty($nick) ? HTML::chars( $this->name ) : HTML::chars($nick);
 		}
 
 		if( $field === 'rawurl' )

--- a/modules/user/views/admin/role/list.php
+++ b/modules/user/views/admin/role/list.php
@@ -18,10 +18,10 @@
          <?php foreach ($roles as $i => $role): ?>
           <tr id="role-row-<?php echo $role->id ?>" class="<?php echo text::alternate("odd", "even") ?>">
             <td id="role-<?php echo $role->id ?>">
-              <?php echo Html::chars($role->name) ?>
+              <?php echo HTML::chars($role->name) ?>
             </td>
             <td>
-            	<?php echo Html::chars($role->description) ?>
+            	<?php echo HTML::chars($role->description) ?>
             </td>
             <td><span class="status-<?php echo $role->special == 1 ? 'active' : 'blocked' ?>">
             	<?php echo $role->special == 1 ? __('Yes') : __('No') ?>
@@ -31,8 +31,8 @@
 		<?php if($role->special): ?>
                  <?php echo __('Edit | Delete') ?>
 		<?php else: ?>
-                 <?php echo html::anchor(Route::get('admin/role')->uri(array('action' => 'edit', 'id' => $role->id)), __("Edit"), array('class'=>'action-edit', 'title'=> __('Edit Role'))) ?>
-                 <?php echo html::anchor(Route::get('admin/role')->uri(array('action' => 'delete', 'id' => $role->id)), __("Delete"), array('class'=>'action-delete', 'title'=> __('Delete Role'))) ?>
+                 <?php echo HTML::anchor(Route::get('admin/role')->uri(array('action' => 'edit', 'id' => $role->id)), __("Edit"), array('class'=>'action-edit', 'title'=> __('Edit Role'))) ?>
+                 <?php echo HTML::anchor(Route::get('admin/role')->uri(array('action' => 'delete', 'id' => $role->id)), __("Delete"), array('class'=>'action-delete', 'title'=> __('Delete Role'))) ?>
             	<?php endif ?>
 		</td>
           </tr>

--- a/modules/user/views/admin/user/list.php
+++ b/modules/user/views/admin/user/list.php
@@ -46,8 +46,8 @@
             </td>
 
             <td class="action">
-               <?php echo html::anchor(Route::get('admin/user')->uri(array('action' => 'edit', 'id' => $user->id)), __('Edit'), array('class'=>'action-edit', 'title'=> __('Edit User'))) ?>
-               <?php echo html::anchor(Route::get('admin/user')->uri(array('action' => 'delete', 'id' => $user->id)), __('Delete'), array('class'=>'action-delete', 'title'=> __('Delete User'))) ?>
+               <?php echo HTML::anchor(Route::get('admin/user')->uri(array('action' => 'edit', 'id' => $user->id)), __('Edit'), array('class'=>'action-edit', 'title'=> __('Edit User'))) ?>
+               <?php echo HTML::anchor(Route::get('admin/user')->uri(array('action' => 'delete', 'id' => $user->id)), __('Delete'), array('class'=>'action-delete', 'title'=> __('Delete User'))) ?>
             </td>
           </tr>
           <?php endforeach ?>

--- a/modules/userguide/classes/kohana/kodoc/markdown.php
+++ b/modules/userguide/classes/kohana/kodoc/markdown.php
@@ -143,7 +143,7 @@ class Kohana_Kodoc_Markdown extends MarkdownExtra_Parser {
 	 */
 	function make_heading_id($heading)
 	{
-		$id = url::title($heading, '-', TRUE);
+		$id = URL::title($heading, '-', TRUE);
 		
 		if(isset($this->_heading_ids[$id]))
 		{

--- a/modules/userguide/views/userguide/api/class.php
+++ b/modules/userguide/views/userguide/api/class.php
@@ -34,7 +34,7 @@ for ($i = 0, $split = FALSE, $count = count($interfaces); $i < $count; $i++, $sp
 <?php if ($path = $doc->class->getFilename()): ?>
 Class declared in <tt><?php echo Debug::path($path) ?></tt> on line <?php echo $doc->class->getStartLine() ?>.
 <?php else: ?>
-Class is not declared in a file, it is probably an internal <?php echo html::anchor('http://php.net/manual/class.'.strtolower($doc->class->name).'.php', 'PHP class') ?>.
+Class is not declared in a file, it is probably an internal <?php echo HTML::anchor('http://php.net/manual/class.'.strtolower($doc->class->name).'.php', 'PHP class') ?>.
 <?php endif ?>
 </p>
 

--- a/modules/userguide/views/userguide/api/method.php
+++ b/modules/userguide/views/userguide/api/method.php
@@ -3,7 +3,7 @@
 <?php $declares = $doc->method->getDeclaringClass(); ?>
 <h3 id="<?php echo $doc->method->name ?>">
 	<?php echo $doc->modifiers, $doc->method->name ?>( <?php echo $doc->params ? $doc->params_short() : '' ?>)
-	<small>(defined in <?php echo html::anchor($route->uri(array('class' => $declares->name)), $declares->name, NULL, NULL, TRUE) ?>)</small>
+	<small>(defined in <?php echo HTML::anchor($route->uri(array('class' => $declares->name)), $declares->name, NULL, NULL, TRUE) ?>)</small>
 </h3>
 
 <div class="description">

--- a/modules/userguide/views/userguide/index.php
+++ b/modules/userguide/views/userguide/index.php
@@ -7,7 +7,7 @@
 	<?php foreach($modules as $url => $options): ?>
 	
 		<p>
-			<strong><?php echo html::anchor(Route::get('docs/guide')->uri(array('module' => $url)), $options['name'], NULL, NULL, TRUE) ?></strong> -
+			<strong><?php echo HTML::anchor(Route::get('docs/guide')->uri(array('module' => $url)), $options['name'], NULL, NULL, TRUE) ?></strong> -
 			<?php echo $options['description'] ?>
 		</p>
 	

--- a/modules/userguide/views/userguide/menu.php
+++ b/modules/userguide/views/userguide/menu.php
@@ -5,7 +5,7 @@
 	<ul>
 	<?php foreach($modules as $url => $options): ?>
 	
-		<li><?php echo html::anchor(Route::get('docs/guide')->uri(array('module' => $url)), $options['name'], NULL, NULL, TRUE) ?></li>
+		<li><?php echo HTML::anchor(Route::get('docs/guide')->uri(array('module' => $url)), $options['name'], NULL, NULL, TRUE) ?></li>
 	
 	<?php endforeach; ?>
 	</ul>


### PR DESCRIPTION
Method names and class names must be in strict compliance ( **case sensitive** ). 

This is part of the migration to the Kohana 3.3 ( *see #112, #122 \* ).
For more information, see the documentation for the [PSR standard [0,1,2]](https://github.com/php-fig/fig-standards/tree/master/accepted)

See diff
