### PR TITLE
Now Kohana::$locale is Gleez_Locale

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -64,6 +64,7 @@ if (isset($_SERVER['KOHANA_ENV']))
  * - boolean  errors      enable or disable error handling                   TRUE
  * - boolean  profile     enable or disable internal profiling               TRUE
  * - boolean  caching     enable or disable internal caching                 FALSE
+ * - boolean  autolocale  enable or disable autodetect locale                TRUE
  */
 Kohana::init(array(
 	'base_url'   => '/',

--- a/modules/gleez/classes/kohana.php
+++ b/modules/gleez/classes/kohana.php
@@ -139,6 +139,23 @@ class Kohana {
 	public static $config;
 
 	/**
+	 * Public [Gleez_Locale] object
+	 *
+	 * @todo In the future, this object should be moved to Gleez Core
+	 *
+	 * @var Gleez_Locale
+	 */
+	public static $locale = NULL;
+
+	/**
+	 * The switch for the [Gleez_Locale]
+	 *
+	 * @todo In the future, this variable should be moved to Gleez Core
+	 *
+	 * @var boolean
+	 */
+	public static $autolocale = TRUE;
+	/**
 	 * @var  boolean  Has [Kohana::init] been called?
 	 */
 	protected static $_init = FALSE;
@@ -233,10 +250,25 @@ class Kohana {
 			set_error_handler(array('Kohana', 'error_handler'));
 		}
 
-		// Setting locale
+		if (isset($settings['autolocale']))
+		{
+			// Manual enable Gleez_Locale
+			if ($settings['autolocale'] === TRUE)
+			{
+				Kohana::$locale = new Gleez_Locale();
+			}
+		}
+		elseif (Kohana::$autolocale)
+		{
+			// By default enable Gleez_Locale
+			Kohana::$locale = new Gleez_Locale();
+		}
+
 		// @todo Set/Get lang from/to Cookie/Session
-		$locale = new Gleez_Locale();
-		I18n::$lang = $locale->get_language();
+		if (Kohana::$locale AND Kohana::$autolocale)
+		{
+			I18n::$lang = Kohana::$locale->get_language();
+		}
 
 		// Enable the Kohana shutdown handler, which catches E_FATAL errors.
 		register_shutdown_function(array('Kohana', 'shutdown_handler'));


### PR DESCRIPTION
**We now have a global object, which we can use at any place as you like.**

Global locale object creation is enabled by default, but this behavior can be changed by setting in the Kohana::init the 'autolocale' parameter as FALSE.

Usage:

``` php
   Kohana::$locale->some_method()
```

@todo In the future, this object should be moved to Gleez Core

This is part of #368
