### PR TITLE
Unified cache driver

### DIFF
--- a/modules/gleez/classes/acl.php
+++ b/modules/gleez/classes/acl.php
@@ -16,7 +16,7 @@
  * - Any ORM implementation
  *
  * @package    Gleez\ACL
- * @version    2.0.0
+ * @version    2.1.0
  * @author     Sandeep Sangamreddi - Gleez
  * @author     Sergey Yakovlev - Gleez
  * @copyright  (c) 2011-2013 Gleez Technologies
@@ -107,18 +107,19 @@ class ACL {
 	/**
 	 * Sets up a named Permission and returns it.
 	 *
-	 * Example:<br>
-	 * <code>
+	 * Example:
+	 * ~~~
 	 *  ACL::set('admin/widgets',
 	 *    array(
 	 *      'administer site widgets',
 	 *      'administer admin widgets'
 	 *    )
 	 * );
-	 * </code>
+	 * ~~~
 	 *
 	 * @param   string  $name          Permission name
 	 * @param   array   $access_names  Access keys
+	 *
 	 * @return  ACL
 	 */
 	public static function set($name, array $access_names)
@@ -130,10 +131,10 @@ class ACL {
 	/**
 	 * Retrieves all named permissions
 	 *
-	 * Example:<br>
-	 * <code>
-	 *  $permissions = ACL::all();
-	 * </code>
+	 * Example:
+	 * ~~~
+	 * $permissions = ACL::all();
+	 * ~~~
 	 *
 	 * @return  array  Perms by name
 	 */
@@ -143,38 +144,41 @@ class ACL {
 	}
 
 	/**
-	 * Saves or loads the ACL cache
+	 * Setter/Getter for ACL cache
 	 *
-	 * If your perms will remain the same for a long period of time,
-	 * use this to reload the ACL from the cache rather than
-	 * redefining them on every page load.
+	 * If your perms will remain the same for a long period of time, use this
+	 * to reload the ACL from the cache rather than redefining them on every page load.
 	 *
-	 * Example:<br>
-	 * <code>
+	 * Example:
+	 * ~~~
 	 *  if ( ! ACL::cache())
 	 *  {
 	 *    // Set perms here
 	 *    ACL::cache(TRUE);
 	 *  }
-	 * </code>
+	 * ~~~
 	 *
-	 * @param   boolean $save   Cache the current perms
-	 * @param   boolean $append Append, rather than replace, cached perms when loading
-	 * @return  void            When saving perms
-	 * @return  boolean         When loading perms
-	 * @uses    Kohana::cache
+	 * @param   boolean  $save    Cache the current perms [Optional]
+	 * @param   boolean  $append  Append, rather than replace, cached perms when loading [Optional]
+	 *
+	 * @return  boolean
+	 *
+	 * @uses    Cache::set
+	 * @uses    Cache::get
 	 * @uses    Arr::merge
 	 */
 	public static function cache($save = FALSE, $append = FALSE)
 	{
+		$cache = Cache::instance();
+
 		if ($save)
 		{
 			// Cache all defined perms
-			Kohana::cache('ACL::cache()', ACL::$_all_perms);
+			return $cache->set('ACL::cache()', ACL::$_all_perms);
 		}
 		else
 		{
-			if ($perms = Kohana::cache('ACL::cache()'))
+			if ($perms = $cache->get('ACL::cache()'))
 			{
 				if ($append)
 				{
@@ -204,26 +208,28 @@ class ACL {
 	 * If the user doesn't have this permission,
 	 * failed with an HTTP_Exception_403 or execute `$callback` if it is defined
 	 *
-	 * Example with a callable function:<br>
-	 * <code>
+	 * Example:
+	 * ~~~
+	 * // Example with a callable function
 	 * ACL::required(
 	 *    'administer site',
 	 *    NULL,
 	 *    $this->request->redirect(Route::get('user')->uri(array('action' => 'login')))
 	 * );
-	 * </code>
 	 *
-	 * Simple check:<br>
-	 * <code>
+	 * // Simple check
 	 *   ACL::required('administer site');
-	 * </code>
+	 * ~~~
 	 *
 	 * @since     2.0
+	 *
 	 * @param     string      $perm_name  Permission name
 	 * @param     Model_User  $user       User object [Optional]
 	 * @param     callable    $callback   A callable function that execute if it is defined [Optional]
 	 * @param     array       $args       The callback arguments
+	 *
 	 * @return    boolean
+	 *
 	 * @throws    HTTP_Exception_403 If the user doesn't have permission
 	 * @throws    Exception          if the `$callback` is a not valid callback
 	 */
@@ -264,7 +270,9 @@ class ACL {
 	 * @param  string  $perm_name  Permission name
 	 * @param  string  $route      Route name [Optional]
 	 * @param  array   $uri        Additional route params [Optional]
+	 *
 	 * @throws HTTP_Exception_403
+	 *
 	 * @uses   Request::redirect()
 	 * @uses   Route::get()
 	 */
@@ -297,7 +305,9 @@ class ACL {
 	 *
 	 * @param   string      $perm_name  Permission name
 	 * @param   Model_User  $user       User object [Optional]
+	 *
 	 * @return  boolean
+	 *
 	 * @uses    User::active_user
 	 */
 	public static function check($perm_name, Model_User $user = NULL)
@@ -371,6 +381,7 @@ class ACL {
 	 * Added cache support for performance.
 	 *
 	 * @since   2.0
+	 *
 	 * @return  boolean  FALSE If the role(s) doesn't have any permission
 	 * @return  array    Role(s) with permission(s) as array
 	 */
@@ -453,8 +464,11 @@ class ACL {
 	 * @param   ORM        $post    The post object
 	 * @param   Model_User $user    The user object to check permission, defaults to loaded in user
 	 * @param   string     $misc    The misc element usually `id|slug` for logging purpose
+	 *
 	 * @return  boolean
+	 *
 	 * @throws  HTTP_Exception_404
+	 *
 	 * @uses    User::active_user
 	 * @uses    Module::event
 	 */
@@ -554,8 +568,11 @@ class ACL {
 	 * @param   ORM        $comment  The comment object
 	 * @param   Model_User $user     The user object to check permission, defaults to loaded in user
 	 * @param   string     $misc     The misc element usually `id|slug` for logging purpose
+	 *
 	 * @return  boolean
+	 *
 	 * @throws  HTTP_Exception_404
+	 *
 	 * @uses    User::active_user
 	 * @uses    Module::event
 	 */

--- a/modules/gleez/classes/gleez/filter.php
+++ b/modules/gleez/classes/gleez/filter.php
@@ -1,39 +1,48 @@
-<?php defined('SYSPATH') or die('No direct access allowed.');
+<?php defined('SYSPATH') OR die('No direct access allowed.');
 /**
  * Input Filter
  *
  * Filter object to clean a string.
- * Note: by design, this class does not do any permission checking.
+ *
+ * [!!] Note: by design, this class does not do any permission checking.
  *
  * @package    Gleez\HTML
  * @author     Sandeep Sangamreddi - Gleez
- * @copyright  (c) 2012 Gleez Technologies
+ * @version    1.1.0
+ * @copyright  (c) 2011-2013 Gleez Technologies
  * @license    http://gleezcms.org/license  Gleez CMS License
  */
 class Gleez_Filter {
 
 	/**
-	 * @var  array
+	 * An array of Filters
+	 * @var array
 	 */
 	protected static $_filters = array();
 
 	/**
-	 * @var  bool Indicates whether filters are cached
+	 * Indicates whether filters are cached
+	 * @var boolean
 	 */
 	public static $cache = FALSE;
 
 	/**
-	 * Stores a named filter and returns it. The "action" will always be set to
-	 * "index" if it is not defined.
+	 * Stores a named filter and returns it
 	 *
-	 *     Filter::set('html', array('prepare callback' => FALSE, 'process callback' => 'Text::html' ) )
-	 *              ->settings(array(
-	 *                      'html_nofollow' => true,
-	 *                      'allowed_html'  => '<a> <em> <strong> <cite> <blockquote>'
-	 *              ));
+	 * The "action" will always be set to "index" if it is not defined.
 	 *
-	 * @param   string   filter name
-	 * @param   array    filter callbacks
+	 * Example:
+	 * ~~~
+	 * Filter::set('html', array('prepare callback' => FALSE, 'process callback' => 'Text::html' ) )
+	 *          ->settings(array(
+	 *                  'html_nofollow' => true,
+	 *                  'allowed_html'  => '<a> <em> <strong> <cite> <blockquote>'
+	 *          ));
+	 * ~~~
+	 *
+	 * @param   string  $name       Filter name
+	 * @param   array   $callbacks  Filter callbacks
+	 *
 	 * @return  Route
 	 */
 	public static function set($name, $callbacks = array())
@@ -42,12 +51,17 @@ class Gleez_Filter {
 	}
 
 	/**
-	 * Retrieves a named filter.
+	 * Retrieves a named filter
 	 *
-	 *     $filter = Filter::get('html');
+	 * Example:
+	 * ~~~
+	 * $filter = Filter::get('html');
+	 * ~~~
 	 *
 	 * @param   string  filter name
+	 *
 	 * @return  Filter
+	 *
 	 * @throws  Gleez_Exception
 	 */
 	public static function get($name)
@@ -62,28 +76,38 @@ class Gleez_Filter {
 	}
 
 	/**
-	 * Retrive(s) all named filters.
+	 * Retrieve(s) all named filters
 	 *
-	 *     $filters = Filter::all();
+	 * Example:
+	 * ~~~
+	 * $filters = Filter::all();
+	 * ~~~
 	 *
-	 * @return  array  filter by name
+	 * @return  array
 	 */
 	public static function all()
 	{
 		return Filter::$_filters;
 	}
 
-		/**
-		 * Retrive(s) all available formats from config
-		 *
-		 * $formats = Filter::formats();
-		 * @return  array  format by name
-		 */
+	/**
+	 * Retrieve(s) all available format by name formats from config
+	 *
+	 * Example:
+	 * ~~~
+	 * $formats = Filter::formats();
+	 * ~~~
+	 *
+	 * @return  array
+	 *
+	 * @uses    Config::load
+	 */
 	public static function formats()
 	{
-		$config = Kohana::$config->load('inputfilter');
+		$config = Config::load('inputfilter');
 
 		$formats = array();
+
 		foreach($config->formats as $id => $format)
 		{
 			$formats[$id] = $format['name'];
@@ -93,32 +117,40 @@ class Gleez_Filter {
 	}
 
 	/**
-	 * Saves or loads the filter cache. If your filters will remain the same for
-	 * a long period of time, use this to reload the filters from the cache
-	 * rather than redefining them on every page load.
+	 * Setter/Getter for the filter cache
 	 *
-	 *     if ( ! Filter::cache())
-	 *     {
-	 *         // Set filters here
-	 *         Filter::cache(TRUE);
-	 *     }
+	 * If your filters will remain the same for a long period of time,
+	 * use this to reload the filters from the cache rather than redefining
+	 * them on every page load.
 	 *
-	 * @param   boolean $save   cache the current filters
-	 * @param   boolean $append append, rather than replace, cached filters when loading
-	 * @return  void    when saving filters
-	 * @return  boolean when loading filters
-	 * @uses    Kohana::cache
+	 * Example:
+	 * ~~~
+	 * if ( ! Filter::cache())
+	 * {
+	 *     // Set filters here
+	 *     Filter::cache(TRUE);
+	 * }
+	 *
+	 * @param   boolean  $save    Cache the current filters [Optional]
+	 * @param   boolean  $append  Append, rather than replace, cached filters when loading [Optional]
+	 *
+	 * @return  boolean
+	 *
+	 * @uses    Cache::get
+	 * @uses    Cache::set
 	 */
 	public static function cache($save = FALSE, $append = FALSE)
 	{
-		if ($save === TRUE)
+		$cache = Cache::instance();
+
+		if ($save)
 		{
 			// Cache all defined routes
-			Kohana::cache('Filter::cache()', Filter::$_filters);
+			return $cache->set('Filter::cache()', Filter::$_filters);
 		}
 		else
 		{
-			if ($filters = Kohana::cache('Filter::cache()'))
+			if ($filters = $cache->get('Filter::cache()'))
 			{
 				if ($append)
 				{
@@ -144,10 +176,10 @@ class Gleez_Filter {
 
 	/**
 	 * Method to run all enabled filters by the format id on given string
-		 *
-		 * @param  object  $text       The text object to be filtered.
-		 * @return string  $text       The filtered text
-		 */
+	 *
+	 * @param  object  $text       The text object to be filtered.
+	 * @return string  $text       The filtered text
+	 */
 	public static function process($text)
 	{
 		$config = Kohana::$config->load('inputfilter');
@@ -186,120 +218,132 @@ class Gleez_Filter {
 		return $text->text;
 	}
 
-		/**
-		 * Execute a filter on the given text
-		 *
-		 * @param  mixed   $callback   The callback to be executed.
-		 * @param  string  $text       The text to be filtered.
-		 * @param  string  $format     The format id of the text to be filtered.
-		 * @param  object  $filter     The filter object.
-		 *
-		 * @return string  $text       The filtered text
-		 */
-		public static function execute($callback, $text, $format, $filter)
-		{
-				$args = func_get_args();
-				array_shift($args);
+	/**
+	 * Execute a filter on the given text
+	 *
+	 * @param  mixed   $callback   The callback to be executed.
+	 * @param  string  $text       The text to be filtered.
+	 * @param  string  $format     The format id of the text to be filtered.
+	 * @param  object  $filter     The filter object.
+	 *
+	 * @return string  $text       The filtered text
+	 */
+	public static function execute($callback, $text, $format, $filter)
+	{
+		$args = func_get_args();
+		array_shift($args);
 
-				if (is_string($callback) AND strpos($callback, '::') !== FALSE)
+		if (is_string($callback) AND strpos($callback, '::') !== FALSE)
 		{
 			// Make the static callback into an array
 			$callback = explode('::', $callback, 2);
 		}
 
-				if ($callback AND is_callable($callback))
+		if ($callback AND is_callable($callback))
 		{
-						try
-						{
-							return  call_user_func_array($callback, $args);
-						}
-						catch (Exception $e)
-						{
-								Kohana::$log->add(Log::ERROR, __('Filter callback :class for :filter',
-																 array(':class' => $e->getMessage(), 'filter' => $filter['name'])));
-								return $text;
-						}
-				}
+			try
+			{
+				return  call_user_func_array($callback, $args);
+			}
+			catch (Exception $e)
+			{
+				Kohana::$log->add(Log::ERROR, 'Filter callback :class for :filter', array(
+						':class' => $e->getMessage(),
+						'filter' => $filter['name']
+				));
 
 				return $text;
+			}
 		}
 
+		return $text;
+	}
+
 	/**
-	 * @var  string  Filter Title
+	 * Filter Title
+	 * @var string
 	 */
 	protected $_title = '';
 
 	/**
-	 * @var  callbacks     The prepare and process callbacks for filter
+	 * The prepare and process callbacks for filter
+	 * @var array
 	 */
 	protected $_callbacks = array('prepare callback' => FALSE, 'process callback' => FALSE);
 
-		/**
-	 * @var  array Filter Settings
+	/**
+	 * Filter Settings
+	 * @var array
 	 */
 	protected $_settings = array();
 
 	/**
-	 * @var  string  Filter Description
+	 * Filter Description
+	 * @var string
 	 */
 	protected $_description = '';
 
-		/**
-	 * @param   string   filter title
-	 * @param   array    filter callbacks
-	 * @return  void
+	/**
+	 * Class constructor
+	 *
+	 * @param  string  $title      Filter title
+	 * @param  array   $callbacks  Filter callbacks
 	 */
 	public function __construct($title, $callbacks = array())
 	{
-				$this->_title = $title;
-				$this->_callbacks = $callbacks;
-		}
+		$this->_title = $title;
+		$this->_callbacks = $callbacks;
+	}
 
-		public function __get($key)
+	public function __get($key)
+	{
+		if($key == 'title')
 		{
-				if($key == 'title')
-				{
-						return $this->_title;
-				}
-				else if($key == 'description')
-				{
-						return $this->_description;
-				}
-				else if($key == 'prepare_callback')
-				{
-						return $this->_callbacks['prepare callback'];
-				}
-				else if($key == 'process_callback')
-				{
-						return $this->_callbacks['process callback'];
-				}
-				else if($key == 'callbacks')
-				{
-						return $this->_callbacks;
-				}
-				else if($key == 'settings')
-				{
-						return $this->_settings;
-				}
-				else
-				{
-						throw new Gleez_Exception('The requested property does not exist: :key',
-				array(':key' => $key));
-				}
+				return $this->_title;
 		}
+		else if($key == 'description')
+		{
+				return $this->_description;
+		}
+		else if($key == 'prepare_callback')
+		{
+				return $this->_callbacks['prepare callback'];
+		}
+		else if($key == 'process_callback')
+		{
+				return $this->_callbacks['process callback'];
+		}
+		else if($key == 'callbacks')
+		{
+				return $this->_callbacks;
+		}
+		else if($key == 'settings')
+		{
+				return $this->_settings;
+		}
+		else
+		{
+				throw new Gleez_Exception('The requested property does not exist: :key',
+		array(':key' => $key));
+		}
+	}
 
 	/**
 	 * Set or get callbacks for filter
 	 *
-	 *     $filter->callbacks(array(
-	 *         'prepare callback'   => FALSE,
-	 *         'process callback'   => 'Text::html'
-	 *     ));
+	 * Example:
+	 * ~~~
+	 * $filter->callbacks(array(
+	 *     'prepare callback'  => FALSE,
+	 *     'process callback'  => 'Text::html'
+	 * ));
+	 * ~~~
 	 *
 	 * If no parameter is passed, this method will act as a getter.
 	 *
-	 * @param   array  key values
-	 * @return  $this or array
+	 * @param   array  $callbacks  key values
+	 *
+	 * @return  array|Filter
 	 */
 	public function callbacks(array $callbacks = NULL)
 	{
@@ -316,15 +360,19 @@ class Gleez_Filter {
 	/**
 	 * Set or get settings for filter
 	 *
-	 *     $filter->settings(array(
-	 *         'html_nofollow' => true,
-	 *         'allowed_html'  => '<a> <em> <strong> <cite> <blockquote>'
-	 *     ));
+	 * Example:
+	 * ~~~
+	 * $filter->settings(array(
+	 *     'html_nofollow' => true,
+	 *     'allowed_html'  => '<a> <em> <strong> <cite> <blockquote>'
+	 * ));
+	 * ~~~
 	 *
 	 * If no parameter is passed, this method will act as a getter.
 	 *
-	 * @param   array  key values
-	 * @return  $this or array
+	 * @param   array  $settings  key values
+	 *
+	 * @return  array|Filter
 	 */
 	public function settings(array $settings = NULL)
 	{
@@ -338,15 +386,19 @@ class Gleez_Filter {
 		return $this;
 	}
 
-		/**
+	/**
 	 * Set or get title for filter
 	 *
-	 *     $filter->title(__('Limit allowed HTML tags'));
+	 * Example:
+	 * ~~~
+	 * $filter->title(__('Limit allowed HTML tags'));
+	 * ~~~
 	 *
 	 * If no parameter is passed, this method will act as a getter.
 	 *
-	 * @param   string  title
-	 * @return  $this or string
+	 * @param   string  $title  Title
+	 *
+	 * @return  array|Filter
 	 */
 	public function title($title = NULL)
 	{
@@ -360,15 +412,19 @@ class Gleez_Filter {
 		return $this;
 	}
 
-		/**
+	/**
 	 * Set or get description for filter
 	 *
-	 *     $filter->description(__('Allowed HTML tags'));
+	 * Example:
+	 * ~~~
+	 * $filter->description(__('Allowed HTML tags'));
+	 * ~~~
 	 *
 	 * If no parameter is passed, this method will act as a getter.
 	 *
-	 * @param   string  description
-	 * @return  $this or string
+	 * @param   string  $description  Description
+	 *
+	 * @return  string|Filter
 	 */
 	public function description($description = NULL)
 	{

--- a/modules/gleez/classes/route.php
+++ b/modules/gleez/classes/route.php
@@ -27,21 +27,26 @@
  * Routes also provide a way to generate URIs (called "reverse routing"), which
  * makes them an extremely powerful and flexible way to generate internal links.
  *
- * @package    Kohana
- * @category   Base
+ * @package    Gleez\Base
+ * @version    2.1.0
+ * @author     Sandeep Sangamreddi - Gleez
+ * @author     Sergey Yakovlev - Gleez
  * @author     Kohana Team
+ * @version    1.1.0
+ * @copyright  (c) 2011-2013 Gleez Technologies
  * @copyright  (c) 2008-2012 Kohana Team
+ * @license    http://gleezcms.org/license  Gleez CMS License
  * @license    http://kohanaframework.org/license
  */
 class Route {
 
-	// Defines the pattern of a <segment>
+	/* Defines the pattern of a <segment> */
 	const REGEX_KEY     = '<([a-zA-Z0-9_]++)>';
 
-	// What can be part of a <segment> value
+	/* What can be part of a <segment> value */
 	const REGEX_SEGMENT = '[^/.,;?\n]++';
 
-	// What must be escaped in the route regex
+	/* What must be escaped in the route regex */
 	const REGEX_ESCAPE  = '[.\\+*?[^\\]${}=!|]';
 
 	/**
@@ -136,42 +141,53 @@ class Route {
 	}
 
 	/**
-	 * Saves or loads the route cache. If your routes will remain the same for
-	 * a long period of time, use this to reload the routes from the cache
-	 * rather than redefining them on every page load.
+	 * Setter/Getter for the route
 	 *
-	 *     if ( ! Route::cache())
-	 *     {
-	 *         // Set routes here
-	 *         Route::cache(TRUE);
-	 *     }
+	 * If your routes will remain the same for a long period of time,
+	 * use this to reload the routes from the cache rather than redefining
+	 * them on every page load.
 	 *
-	 * @param   boolean $save   cache the current routes
-	 * @param   boolean $append append, rather than replace, cached routes when loading
-	 * @return  void    when saving routes
-	 * @return  boolean when loading routes
-	 * @uses    Kohana::cache
+	 * Example:
+	 * ~~~
+	 * if ( ! Route::cache())
+	 * {
+	 *     // Set routes here
+	 *     Route::cache(TRUE);
+	 * }
+	 * ~~~
+	 *
+	 * @param   boolean $save    Cache the current routes [Optional]
+	 * @param   boolean $append  Append, rather than replace, cached routes when loading [Optional]
+	 *
+	 * @return  boolean
+	 *
+	 * @throws  Gleez_Exception
+	 *
+	 * @uses    Cache::get
+	 * @uses    Cache::set
 	 */
 	public static function cache($save = FALSE, $append = FALSE)
 	{
-		if ($save === TRUE)
+		$cache = Cache::instance();
+
+		if ($save)
 		{
 			try
 			{
 				// Cache all defined routes
-				Kohana::cache('Route::cache()', Route::$_routes);
+				return $cache->set('Route::cache()', Route::$_routes);
 			}
 			catch (Exception $e)
 			{
 				// We most likely have a lambda in a route, which cannot be cached
-				throw new Gleez_Exception('One or more routes could not be cached (:message)', array(
-						':message' => $e->getMessage(),
-					), 0, $e);
+				throw new Gleez_Exception('One or more routes could not be cached (:message)',
+					array(':message' => $e->getMessage()),	0,	$e
+				);
 			}
 		}
 		else
 		{
-			if ($routes = Kohana::cache('Route::cache()'))
+			if ($routes = $cache->get('Route::cache()'))
 			{
 				if ($append)
 				{


### PR DESCRIPTION
This is the beginning of work on the unification of all calls and appeals to the driver cache.
- Updated: Now **ACL**, **Filter** and **Route** will use `Cache::instance` as way to call current default cache driver. Removed in these classes `Kohana::cache` and used simply `Cache::instance()->get()->set()`. In future it will be replaced by one object `Gleez::$cache`
- Fixed: Cleanup & added PHPDoc
- Fixed: Minor cleanup spaces & code
