### PR TITLE
Disabled Cerber Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/mango"]
 	path = modules/mango
 	url = https://github.com/sergeyklay/gleez-mango.git
-[submodule "themes/cerber"]
-	path = themes/cerber
-	url = https://github.com/sergeyklay/gleez-cerber.git
+#[submodule "themes/cerber"]
+#	path = themes/cerber
+#	url = https://github.com/sergeyklay/gleez-cerber.git


### PR DESCRIPTION
Temporarily disabled Cerber Theme for the reason that Gleez uses a new API but Cerber has not had time to adapt.
At this moment, rewritten some basic things for Cerber Theme, but not all.

**Please, temporarily use Fluid Theme**

Version 1.0 coming soon!
