### PR TITLE
Fixed HTML::attributes

### DIFF
--- a/modules/gleez/classes/html.php
+++ b/modules/gleez/classes/html.php
@@ -7,7 +7,7 @@
  *
  * @package    Gleez\Helpers
  * @author     Gleez Team
- * @version    1.1.0
+ * @version    1.1.1
  * @copyright  (c) 2011-2013 Gleez Technologies
  * @license    http://gleezcms.org/license  Gleez CMS License
  */
@@ -345,7 +345,7 @@ class HTML {
 			// Add the attribute key
 			$compiled .= ' '.$key;
 
-			if ($value OR self::$strict)
+			if ($value !== FALSE OR self::$strict)
 			{
 				// Add the attribute value
 				$compiled .= '="'.self::chars($value).'"';


### PR DESCRIPTION
When passing in a 0 (integer) as a value, `HTML::attributes` would render it blank because it was detecting it as **FALSE**. With this little change, it'd be looking for a `!==` match.

Thanks to @JackEllis
