### PR TITLE
Gleez Num v1.2.0

### DIFF
--- a/modules/gleez/classes/num.php
+++ b/modules/gleez/classes/num.php
@@ -6,7 +6,7 @@
  *
  * @package    Gleez\Helpers
  * @author     Gleez Team
- * @version    1.1.0
+ * @version    1.2.0
  * @copyright  (c) 2011-2014 Gleez Technologies
  * @license    http://gleezcms.org/license  Gleez CMS License
  */
@@ -287,5 +287,45 @@ class Num {
 		}
 
 		return $bytes;
+	}
+
+	/**
+	 * Get the IPv4 dotted format address from integer
+	 *
+	 * Example:
+	 * ~~~
+	 * echo Num::toIPv4(4294967295); // 255.255.255.255
+	 * echo Num::toIPv4(3221234342); // 192.0.34.166
+	 * ~~~
+	 *
+	 * @since  1.2.0
+	 *
+	 * @param  int $integer_ip An integer value
+	 * @return string
+	 */
+	public static function toIPv4($integer_ip)
+	{
+		return long2ip((int)$integer_ip);
+	}
+
+	/**
+	 * Get the integer value of an IPv4 dotted format address
+	 *
+	 * Example:
+	 * ~~~
+	 * echo Num::fromIPv4('255.255.255.255'); // 4294967295
+	 * echo Num::fromIPv4('192.0.34.166');    // 3221234342
+	 * ~~~
+	 *
+	 * @since  1.2.0
+	 *
+	 * @param  string $dottet_ip An standard IPv4 format address
+	 * @return int
+	 */
+	public static function fromIPv4($dottet_ip)
+	{
+		return  (substr($dottet_ip, 0, 3) > 127)
+			? ((ip2long($dottet_ip) & 0x7FFFFFFF) + 0x80000000)
+			: ip2long($dottet_ip);
 	}
 }


### PR DESCRIPTION
- `Num::toIPv4`  — Get the IPv4 dotted format address from integer:

``` php
echo Num::toIPv4(4294967295); // 255.255.255.255
echo Num::toIPv4(3221234342); // 192.0.34.166
```
- `Num::fromIPv4` — Get the integer value from IPv4 dotted format address:

``` php
echo Num::fromIPv4('255.255.255.255'); // 4294967295
echo Num::fromIPv4('192.0.34.166');    // 3221234342
```

**Algorithm**:
_IP_:    A.B.C.D
_INT_:  A × 256³ + B × 256² + C × 256¹ + D

**Example**:
_IP_:    192.0.34.166
_INT_:  192 × 256³ + 0 × 256² + 34 × 256¹ + 166 =
             192 × 16777216 + 34 × 256 + 166 =
             3221225472 + 8704 + 166 =
             3221234342
