### PR TITLE
Remove empty font-family entry, fix wording

### DIFF
--- a/modules/codebench/media/css/codebench.css
+++ b/modules/codebench/media/css/codebench.css
@@ -4,7 +4,6 @@ body {
   position: relative;
   margin: 1em 2em;
   font: 13px/1.7em Menlo, Monaco, Consolas, "Courier New", monospace;
-  font-family: 
 }
 
 h1 {

--- a/modules/user/messages/models/mail.php
+++ b/modules/user/messages/models/mail.php
@@ -3,7 +3,7 @@
 return array(
 	'mail' => array(
 		'not_empty' => 'You must provide an email address',
-		'email_not_available' => "This email don't exists",
+		'email_not_available' => "Email address does not exist",
 		'email' => 'Mail must be a valid email address',
 	),
 );


### PR DESCRIPTION
The empty font-family entry in the codebench.css file isn't necessary, the font family is set in the previous line:
```
font: 13px/1.7em Menlo, Monaco, Consolas, "Courier New", monospace;
```

Additionally, changed the wording of the email_not_available messages entry to make grammatical sense.